### PR TITLE
feat: add support for jira.com domain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The action can also automatically update the 'Fix Version' field of a list of Ji
 |---|---|---|
 | email  | Jira login | Y |
 | api_token | Jira api token | Y |
-| subdomain | Jira cloud instance. '[domain].atlassian.net' | Y |
+| subdomain | Jira cloud instance account subdomain. '[subdomain].atlassian.net' | Y |
+| domain | Jira cloud instance root domain. | N (default: atlassian.net) |
 | jira_project | Key of the jira project | Y |
 | release_name | Name of the release | Y |
 | create | Boolean. Create automatically a jira release| N (default: false ) |

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   subdomain:
     required: true
     description: '{subdomain}.atlassian.net'
+  domain:
+    required: false
+    description: Jira cloud domain
+    default: atlassian.net
   jira_project:
     required: true
     description: 'Id of the JIRA project'
@@ -20,7 +24,7 @@ inputs:
   create:
     required: false
     description: Automatically create the release if not present in Jira
-    default: 'false' 
+    default: 'false'
   tickets:
     required: false
     description: Comma separated list of ticket IDs to include in the release. Update the first release-version.

--- a/src/api.ts
+++ b/src/api.ts
@@ -31,7 +31,7 @@ export class Project {
   async createVersion(version: Version): Promise<Version> {
     try {
       const response = await axios.post(
-        `https://${this.domain}.atlassian.net/rest/api/3/version`,
+        `https://${this.domain}/rest/api/3/version`,
         version,
         this._authHeaders()
       )
@@ -45,7 +45,7 @@ export class Project {
     try {
       core.debug(JSON.stringify(version))
       const response = await axios.put(
-        `https://${this.domain}.atlassian.net/rest/api/3/version/${version.id}`,
+        `https://${this.domain}/rest/api/3/version/${version.id}`,
         version,
         this._authHeaders()
       )
@@ -59,7 +59,7 @@ export class Project {
   async updateIssue(ticket: string, version: string) {
     try {
       const response = await axios.put(
-        `https://${this.domain}.atlassian.net/rest/api/3/issue/${ticket}`,
+        `https://${this.domain}/rest/api/3/issue/${ticket}`,
         {
           update: {
             fixVersions: [
@@ -90,7 +90,7 @@ export class Project {
   async _load(): Promise<Project> {
     try {
       const response = await axios.get(
-        `https://${this.domain}.atlassian.net/rest/api/3/project/${this.name}?properties=versions,key,id,name`,
+        `https://${this.domain}/rest/api/3/project/${this.name}?properties=versions,key,id,name`,
         this._authHeaders()
       )
       this.project = response?.data

--- a/src/env.ts
+++ b/src/env.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core'
 
 export const EMAIL: string = core.getInput('email', {required: true})
 export const API_TOKEN: string = core.getInput('api_token', {required: true})
+export const DOMAIN: string = core.getInput('domain', {required: false})
 export const SUBDOMAIN: string = core.getInput('subdomain', {required: true})
 
 export const RELEASE_NAME: string = core.getInput('release_name', {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import {
   EMAIL,
   API_TOKEN,
   SUBDOMAIN,
+  DOMAIN,
   RELEASE_NAME,
   PROJECT,
   CREATE,
@@ -18,20 +19,25 @@ async function run(): Promise<void> {
       core.info(`email ${EMAIL}`)
       core.info(`project ${PROJECT}`)
       core.info(`subdomain ${SUBDOMAIN}`)
+      core.info(`domain ${DOMAIN}`)
       core.info(`release ${RELEASE_NAME}`)
       core.info(`create ${CREATE}`)
       core.info(`tickets ${TICKETS}`)
       return
     }
 
+    const domain = `${SUBDOMAIN}.${DOMAIN || 'atlassian.net'}`
+
     if (DRY_RUN === 'true') {
       core.info(`email ${EMAIL}`)
       core.info(`project ${PROJECT}`)
       core.info(`subdomain ${SUBDOMAIN}`)
+      core.info(`domain ${DOMAIN}`)
       core.info(`release ${RELEASE_NAME}`)
       core.info(`create ${CREATE}`)
       core.info(`tickets ${TICKETS}`)
-      const project = await Project.create(EMAIL, API_TOKEN, PROJECT, SUBDOMAIN)
+
+      const project = await Project.create(EMAIL, API_TOKEN, PROJECT, domain)
       core.info(`Project loaded ${project.project?.id}`)
       const version = project.getVersion(RELEASE_NAME)
 
@@ -43,7 +49,7 @@ async function run(): Promise<void> {
       return
     }
 
-    const project = await Project.create(EMAIL, API_TOKEN, PROJECT, SUBDOMAIN)
+    const project = await Project.create(EMAIL, API_TOKEN, PROJECT, domain)
 
     core.debug(`Project loaded ${project.project?.id}`)
 


### PR DESCRIPTION
Some Jira customers like us have `jira.com` domain address.
https://community.developer.atlassian.com/t/in-what-cases-would-someone-have-a-jira-com-subdomain/13429